### PR TITLE
feat: add passive WHOIS lookup module

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from colorama import init, Fore, Style
 from modules.dns_recon import get_dns_info
 from modules.crtsh_recon import get_crtsh_subdomains
 from modules.hackertarget_recon import get_hackertarget_data
+from modules.whois_recon import get_whois_info
 
 
 BANNER = r"""
@@ -115,14 +116,16 @@ def main() -> None:
         logger.info(f"Starting data aggregation for domain: {args.domain}")
 
         logger.info("Launching concurrent data collection...")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
             future_dns = executor.submit(get_dns_info, args.domain)
             future_crtsh = executor.submit(get_crtsh_subdomains, args.domain)
             future_ht = executor.submit(get_hackertarget_data, args.domain)
+            future_whois = executor.submit(get_whois_info, args.domain)
 
             dns_data = future_dns.result()
             crtsh_data = future_crtsh.result()
             hackertarget_data = future_ht.result()
+            whois_data = future_whois.result()
 
         if dns_data is None:
             logger.error("Skipping report generation due to DNS resolution failure.")
@@ -138,7 +141,8 @@ def main() -> None:
                 "aliases": aliases
             },
             "crtsh_subdomains": crtsh_data if crtsh_data is not None else [],
-            "hackertarget_hosts": hackertarget_data if hackertarget_data is not None else []
+            "hackertarget_hosts": hackertarget_data if hackertarget_data is not None else [],
+            "whois_info": whois_data if whois_data is not None else {}
         }
 
         if args.output:

--- a/modules/whois_recon.py
+++ b/modules/whois_recon.py
@@ -1,0 +1,41 @@
+import logging
+import whois
+
+logger = logging.getLogger(__name__)
+
+
+def get_whois_info(domain: str) -> dict | None:
+    """
+    Perform a passive WHOIS lookup for the given domain using python-whois.
+
+    Returns a dict with registrar, creation_date, expiration_date, and
+    name_servers, or None if the lookup fails.
+    """
+    try:
+        logger.info(f"Querying WHOIS data for: {domain}")
+        w = whois.whois(domain)
+
+        def _serialize_date(val):
+            if val is None:
+                return None
+            if isinstance(val, list):
+                return [v.isoformat() if hasattr(v, "isoformat") else str(v) for v in val]
+            return val.isoformat() if hasattr(val, "isoformat") else str(val)
+
+        def _normalize_list(val):
+            if val is None:
+                return None
+            if isinstance(val, list):
+                return [str(v).lower() for v in val]
+            return [str(val).lower()]
+
+        return {
+            "registrar": w.registrar,
+            "creation_date": _serialize_date(w.creation_date),
+            "expiration_date": _serialize_date(w.expiration_date),
+            "name_servers": _normalize_list(w.name_servers),
+        }
+
+    except Exception as e:
+        logger.warning(f"WHOIS lookup failed for {domain}: {e}")
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 shodan
 colorama
+python-whois


### PR DESCRIPTION
Adds a new passive WHOIS lookup module that queries public WHOIS databases 
and integrates the results into the aggregated JSON report.

## Changes
- `modules/whois_recon.py` — new module using `python-whois` library
- `main.py` — imported module, added concurrent future, added `whois_info` to results dict, bumped `max_workers` to 4
- `requirements.txt` — added `python-whois`

## Output Added
```json
"whois_info": {
    "registrar": "...",
    "creation_date": "...",
    "expiration_date": "...",
    "name_servers": [...]
}
```

- 100% passive — queries public WHOIS databases only, no direct contact with target
- No API key required
- Failures are handled gracefully — returns empty `{}` instead of crashing
- Dates serialized to ISO format, name servers normalized to lowercase
- Runs concurrently with other modules, no performance impact